### PR TITLE
Update for dynamic schema

### DIFF
--- a/mappers/activity_log_mapper.go
+++ b/mappers/activity_log_mapper.go
@@ -7,14 +7,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
 
 	"github.com/turbot/tailpipe-plugin-azure/rows"
-	"github.com/turbot/tailpipe-plugin-sdk/table"
 )
 
 type ActivityLogMapper struct{}
-
-func NewActivityLogMapper() table.Mapper[*rows.ActivityLog] {
-	return &ActivityLogMapper{}
-}
 
 func (m *ActivityLogMapper) Identifier() string {
 	return "azure_activity_log_mapper"

--- a/sources/activity_log_api_source.go
+++ b/sources/activity_log_api_source.go
@@ -51,9 +51,11 @@ func (s *ActivityLogAPISource) Collect(ctx context.Context) error {
 	}
 
 	tpSource := ActivityLogAPISourceIdentifier
-	sourceEnrichmentFields := &enrichment.CommonFields{
-		TpSourceType: ActivityLogAPISourceIdentifier,
-		TpSourceName: &tpSource,
+	sourceEnrichmentFields := &enrichment.SourceEnrichment{
+		CommonFields: enrichment.CommonFields{
+			TpSourceType: ActivityLogAPISourceIdentifier,
+			TpSourceName: &tpSource,
+		},
 	}
 
 	endTime := time.Now()
@@ -83,8 +85,8 @@ func (s *ActivityLogAPISource) Collect(ctx context.Context) error {
 			}
 
 			row := &types.RowData{
-				Data:     logEntry,
-				Metadata: sourceEnrichmentFields,
+				Data:             logEntry,
+				SourceEnrichment: sourceEnrichmentFields,
 			}
 
 			// update collection state

--- a/sources/azure_blob_storage_source.go
+++ b/sources/azure_blob_storage_source.go
@@ -76,13 +76,15 @@ func (s *AzureBlobStorageSource) DiscoverArtifacts(ctx context.Context) error {
 		for _, blob := range page.Segment.BlobItems {
 			objPath := *blob.Name
 			if s.Extensions.IsValid(objPath) {
-				sourceEnrichmentFields := &enrichment.CommonFields{
-					TpSourceLocation: &objPath,
-					TpSourceName:     &s.Config.Container,
-					TpSourceType:     AzureBlobStorageSourceIdentifier,
+				sourceEnrichmentFields := &enrichment.SourceEnrichment{
+					CommonFields: enrichment.CommonFields{
+						TpSourceLocation: &objPath,
+						TpSourceName:     &s.Config.Container,
+						TpSourceType:     AzureBlobStorageSourceIdentifier,
+					},
 				}
 
-				info := &types.ArtifactInfo{Name: objPath, OriginalName: objPath, EnrichmentFields: sourceEnrichmentFields}
+				info := &types.ArtifactInfo{Name: objPath, OriginalName: objPath, SourceEnrichment: sourceEnrichmentFields}
 
 				if err = s.OnArtifactDiscovered(ctx, info); err != nil {
 					// TODO: #error should we continue or fail?
@@ -121,7 +123,7 @@ func (s *AzureBlobStorageSource) DownloadArtifact(ctx context.Context, info *typ
 
 	}
 
-	downloadInfo := &types.ArtifactInfo{Name: localFilePath, OriginalName: info.Name, EnrichmentFields: info.EnrichmentFields}
+	downloadInfo := &types.ArtifactInfo{Name: localFilePath, OriginalName: info.Name, SourceEnrichment: info.SourceEnrichment}
 
 	return s.OnArtifactDownloaded(ctx, downloadInfo)
 }

--- a/tables/activity_log_table.go
+++ b/tables/activity_log_table.go
@@ -1,7 +1,6 @@
 package tables
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/rs/xid"
@@ -31,27 +30,17 @@ func (c *ActivityLogTable) Identifier() string {
 	return ActivityLogTableIdentifier
 }
 
-func (c *ActivityLogTable) SupportedSources(_ *ActivityLogTableConfig) []*table.SourceMetadata[*rows.ActivityLog] {
+func (c *ActivityLogTable) GetSourceMetadata(_ *ActivityLogTableConfig) []*table.SourceMetadata[*rows.ActivityLog] {
 	return []*table.SourceMetadata[*rows.ActivityLog]{
 		{
 			SourceName: sources.ActivityLogAPISourceIdentifier,
-			MapperFunc: mappers.NewActivityLogMapper,
+			Mapper:     &mappers.ActivityLogMapper{},
 		},
 	}
 }
 
-func (c *ActivityLogTable) EnrichRow(row *rows.ActivityLog, sourceEnrichmentFields *enrichment.CommonFields) (*rows.ActivityLog, error) {
-
-	// we expect sourceEnrichmentFields to be set
-	if sourceEnrichmentFields == nil {
-		return nil, fmt.Errorf("ActivityLogTable EnrichRow called with nil sourceEnrichmentFields")
-	}
-	// we expect name to be set by the Source
-	if sourceEnrichmentFields.TpSourceName == nil {
-		return nil, fmt.Errorf("ActivityLogTable EnrichRow called with TpSourceName unset in sourceEnrichmentFields")
-	}
-
-	row.CommonFields = *sourceEnrichmentFields
+func (c *ActivityLogTable) EnrichRow(row *rows.ActivityLog, _ *ActivityLogTableConfig, sourceEnrichmentFields enrichment.SourceEnrichment) (*rows.ActivityLog, error) {
+	row.CommonFields = sourceEnrichmentFields.CommonFields
 
 	// Record Standardization
 	row.TpID = xid.New().String()


### PR DESCRIPTION
- Source now passes SourceEnrichment struct to the Enrich function instead of just CommonFields
- Table.SupportedSources renamed to GetSourceMetadata
- MapperFunc is now just Mapper and should be populated with a mapper instance
- Pointless Mapper constructors removed
- EnrichRow now also takes a config param
- DelimitedLineMapper renamed to RowPatternMapper
