### PR TITLE
Fix broken doc links in the azure_cost_and_actual_actual table

### DIFF
--- a/docs/tables/azure_cost_and_usage_actual/index.md
+++ b/docs/tables/azure_cost_and_usage_actual/index.md
@@ -9,7 +9,7 @@ The `azure_cost_and_usage_actual` table allows you to query data from Azure Cost
 
 ## Configure
 
-Create a [partition](https://tailpipe.io/docs/manage/partition) for `azure_cost_and_usage_actual` ([examples](#example-configurations)):
+Create a [partition](https://tailpipe.io/docs/manage/partition) for `azure_cost_and_usage_actual` ([examples](https://hub.tailpipe.io/plugins/turbot/azure/tables/azure_cost_and_usage_actual#example-configurations)):
 
 ```sh
 vi ~/.tailpipe/config/azure.tpc


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
